### PR TITLE
Configure Dependabot for Maven and Gradle with ignore rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,20 +9,24 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
-    labels:
-      - "dependencies"
-    commit-message:
-      prefix: "deps:"  
+
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+          - "version-update:semver-major" 
 
   # =========================
   # Gradle dependencies
   # =========================
-  - package-ecosystem: "gradle"
+ - package-ecosystem: "gradle"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
-    labels:
-      - "dependencies"
-    commit-message:
-      prefix: "deps:"  
+
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+          - "version-update:semver-major" 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+
+updates:
+  # =========================
+  # Maven dependencies
+  # =========================
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps:"  
+
+  # =========================
+  # Gradle dependencies
+  # =========================
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps:"  


### PR DESCRIPTION
- Blocks PATCH updates
    **for example 4.0.0 → 4.0.1** 
- Blocks MAJOR updates
     **for example  3.2 → 4.0**
- Allows ONLY MINOR updates
     **for example 4.2 → 4.3**