### PR TITLE
Upgrade Spring Boot parent to 4.0.0 and Java 25

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,19 +14,4 @@ updates:
       - dependency-name: "*"
         update-types:
           - "version-update:semver-patch"
-          - "version-update:semver-major" 
-
-  # =========================
-  # Gradle dependencies
-  # =========================
- - package-ecosystem: "gradle"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 3
-
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
-          - "version-update:semver-major" 
+          - "version-update:semver-major"

--- a/spring-boot-2-jdbc-with-h2/.github/dependabot.yml
+++ b/spring-boot-2-jdbc-with-h2/.github/dependabot.yml
@@ -9,7 +9,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
-
+    commit-message:
+      prefix: "deps:"
     ignore:
       - dependency-name: "*"
         update-types:

--- a/spring-boot-2-jdbc-with-h2/.github/dependabot.yml
+++ b/spring-boot-2-jdbc-with-h2/.github/dependabot.yml
@@ -15,18 +15,3 @@ updates:
         update-types:
           - "version-update:semver-patch"
           - "version-update:semver-major" 
-
-  # =========================
-  # Gradle dependencies
-  # =========================
- - package-ecosystem: "gradle"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 3
-
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
-          - "version-update:semver-major" 

--- a/spring-boot-2-jdbc-with-h2/pom.xml
+++ b/spring-boot-2-jdbc-with-h2/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.0-M1</version>
+		<version>4.0.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 
@@ -19,7 +19,7 @@
 	<description>Spring Boot 2, JDBC and H2 - Example Project</description>
 
 	<properties>
-		<java.version>21</java.version>
+		<java.version>25</java.version>
 	</properties>
 
 	<dependencies>
@@ -29,7 +29,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
+			<artifactId>spring-boot-starter-webmvc</artifactId>
 		</dependency>
 
 		<dependency>

--- a/spring-boot-2-jdbc-with-h2/readme.md
+++ b/spring-boot-2-jdbc-with-h2/readme.md
@@ -47,7 +47,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
 
         <dependency>

--- a/spring-boot-2-jpa-spring-data-rest/.github/dependabot.yml
+++ b/spring-boot-2-jpa-spring-data-rest/.github/dependabot.yml
@@ -14,19 +14,4 @@ updates:
       - dependency-name: "*"
         update-types:
           - "version-update:semver-patch"
-          - "version-update:semver-major" 
-
-  # =========================
-  # Gradle dependencies
-  # =========================
- - package-ecosystem: "gradle"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 3
-
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
           - "version-update:semver-major"

--- a/spring-boot-2-jpa-spring-data-rest/.github/dependabot.yml
+++ b/spring-boot-2-jpa-spring-data-rest/.github/dependabot.yml
@@ -9,7 +9,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
-
+    commit-message:
+      prefix: "deps:"
     ignore:
       - dependency-name: "*"
         update-types:

--- a/spring-boot-2-jpa-spring-data-rest/pom.xml
+++ b/spring-boot-2-jpa-spring-data-rest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>
+        <version>4.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -18,7 +18,7 @@
     <description>Spring Boot 2, Hibernate, JPA and H2 - Example Project</description>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
     </properties>
 
     <dependencies>
@@ -34,7 +34,7 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
 
         <dependency>

--- a/spring-boot-2-jpa-spring-data-rest/readme.md
+++ b/spring-boot-2-jpa-spring-data-rest/readme.md
@@ -50,7 +50,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/spring-boot-2-jpa-with-hibernate-and-h2/.github/dependabot.yml
+++ b/spring-boot-2-jpa-with-hibernate-and-h2/.github/dependabot.yml
@@ -14,19 +14,4 @@ updates:
       - dependency-name: "*"
         update-types:
           - "version-update:semver-patch"
-          - "version-update:semver-major" 
-
-  # =========================
-  # Gradle dependencies
-  # =========================
- - package-ecosystem: "gradle"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 3
-
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
           - "version-update:semver-major"

--- a/spring-boot-2-jpa-with-hibernate-and-h2/.github/dependabot.yml
+++ b/spring-boot-2-jpa-with-hibernate-and-h2/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
+    commit-message:
+      prefix: "deps:"
 
     ignore:
       - dependency-name: "*"

--- a/spring-boot-2-jpa-with-hibernate-and-h2/pom.xml
+++ b/spring-boot-2-jpa-with-hibernate-and-h2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>
+        <version>4.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -18,7 +18,7 @@
     <description>Spring Boot 2, Hibernate, JPA and H2 - Example Project</description>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
     </properties>
 
     <dependencies>
@@ -30,7 +30,7 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
 
         <dependency>

--- a/spring-boot-2-jpa-with-hibernate-and-h2/readme.md
+++ b/spring-boot-2-jpa-with-hibernate-and-h2/readme.md
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>
+        <version>4.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -37,7 +37,7 @@
     <description>Spring Boot 2, Hibernate, JPA and H2 - Example Project</description>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
     </properties>
 
     <dependencies>
@@ -49,7 +49,7 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
 
         <dependency>

--- a/spring-boot-2-myBatis-with-h2/.github/dependabot.yml
+++ b/spring-boot-2-myBatis-with-h2/.github/dependabot.yml
@@ -14,19 +14,4 @@ updates:
       - dependency-name: "*"
         update-types:
           - "version-update:semver-patch"
-          - "version-update:semver-major" 
-
-  # =========================
-  # Gradle dependencies
-  # =========================
- - package-ecosystem: "gradle"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 3
-
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
-          - "version-update:semver-major" 
+          - "version-update:semver-major"

--- a/spring-boot-2-myBatis-with-h2/.github/dependabot.yml
+++ b/spring-boot-2-myBatis-with-h2/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
+    commit-message:
+      prefix: "deps:"
 
     ignore:
       - dependency-name: "*"

--- a/spring-boot-2-myBatis-with-h2/pom.xml
+++ b/spring-boot-2-myBatis-with-h2/pom.xml
@@ -18,7 +18,7 @@
 	<description>Spring Boot 2, myBatis and H2 - Example Project</description>
 
 	<properties>
-		<java.version>21</java.version>
+		<java.version>25</java.version>
         <mybatis.version>3.0.5</mybatis.version>
 	</properties>
 
@@ -30,7 +30,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
+			<artifactId>spring-boot-starter-webmvc</artifactId>
 		</dependency>
 
 		<dependency>

--- a/spring-boot-2-myBatis-with-h2/readme.md
+++ b/spring-boot-2-myBatis-with-h2/readme.md
@@ -36,7 +36,7 @@
     <description>Spring Boot 2, myBatis and H2 - Example Project</description>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
         <mybatis.version>3.0.5</mybatis.version>
     </properties>
 
@@ -48,7 +48,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
 
         <dependency>

--- a/spring-boot-2-rest-service-basic/.github/dependabot.yml
+++ b/spring-boot-2-rest-service-basic/.github/dependabot.yml
@@ -14,19 +14,4 @@ updates:
       - dependency-name: "*"
         update-types:
           - "version-update:semver-patch"
-          - "version-update:semver-major" 
-
-  # =========================
-  # Gradle dependencies
-  # =========================
- - package-ecosystem: "gradle"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 3
-
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
           - "version-update:semver-major"

--- a/spring-boot-2-rest-service-basic/.github/dependabot.yml
+++ b/spring-boot-2-rest-service-basic/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
+    commit-message:
+      prefix: "deps:"
 
     ignore:
       - dependency-name: "*"

--- a/spring-boot-2-rest-service-basic/pom.xml
+++ b/spring-boot-2-rest-service-basic/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>
+        <version>4.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -18,7 +18,7 @@
     <description>Spring Boot 2 and REST - Example Project</description>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
     </properties>
 
     <dependencies>
@@ -34,7 +34,7 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
 
         <dependency>

--- a/spring-boot-2-rest-service-basic/readme.md
+++ b/spring-boot-2-rest-service-basic/readme.md
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>
+        <version>4.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -37,7 +37,7 @@
     <description>Spring Boot 2 and REST - Example Project</description>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
     </properties>
 
     <dependencies>
@@ -51,7 +51,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
 
         <dependency>

--- a/spring-boot-2-rest-service-content-negotiation/.github/dependabot.yml
+++ b/spring-boot-2-rest-service-content-negotiation/.github/dependabot.yml
@@ -14,19 +14,4 @@ updates:
       - dependency-name: "*"
         update-types:
           - "version-update:semver-patch"
-          - "version-update:semver-major" 
-
-  # =========================
-  # Gradle dependencies
-  # =========================
- - package-ecosystem: "gradle"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 3
-
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
           - "version-update:semver-major"

--- a/spring-boot-2-rest-service-content-negotiation/.github/dependabot.yml
+++ b/spring-boot-2-rest-service-content-negotiation/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
+    commit-message:
+      prefix: "deps:"
 
     ignore:
       - dependency-name: "*"

--- a/spring-boot-2-rest-service-content-negotiation/pom.xml
+++ b/spring-boot-2-rest-service-content-negotiation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>
+        <version>4.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -18,7 +18,7 @@
     <description>Spring Boot 2 and REST - Example Project</description>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
     </properties>
 
     <dependencies>
@@ -34,7 +34,7 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
 
         <dependency>

--- a/spring-boot-2-rest-service-content-negotiation/readme.md
+++ b/spring-boot-2-rest-service-content-negotiation/readme.md
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>
+        <version>4.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -37,7 +37,7 @@
     <description>Spring Boot 2 and REST - Example Project</description>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
     </properties>
 
     <dependencies>
@@ -51,7 +51,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
 
         <dependency>

--- a/spring-boot-2-rest-service-exception-handling/.github/dependabot.yml
+++ b/spring-boot-2-rest-service-exception-handling/.github/dependabot.yml
@@ -14,19 +14,4 @@ updates:
       - dependency-name: "*"
         update-types:
           - "version-update:semver-patch"
-          - "version-update:semver-major" 
-
-  # =========================
-  # Gradle dependencies
-  # =========================
- - package-ecosystem: "gradle"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 3
-
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
           - "version-update:semver-major"

--- a/spring-boot-2-rest-service-exception-handling/.github/dependabot.yml
+++ b/spring-boot-2-rest-service-exception-handling/.github/dependabot.yml
@@ -9,7 +9,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
-
+    commit-message:
+      prefix: "deps:"
     ignore:
       - dependency-name: "*"
         update-types:

--- a/spring-boot-2-rest-service-exception-handling/pom.xml
+++ b/spring-boot-2-rest-service-exception-handling/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>
+        <version>4.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -18,7 +18,7 @@
     <description>Spring Boot 2 and REST - Example Project</description>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
     </properties>
 
     <dependencies>
@@ -34,7 +34,7 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
 
         <dependency>

--- a/spring-boot-2-rest-service-exception-handling/readme.md
+++ b/spring-boot-2-rest-service-exception-handling/readme.md
@@ -37,7 +37,7 @@
     <description>Spring Boot 2 and REST - Example Project</description>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
     </properties>
 
     <dependencies>
@@ -51,7 +51,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/spring-boot-2-rest-service-filtering/.github/dependabot.yml
+++ b/spring-boot-2-rest-service-filtering/.github/dependabot.yml
@@ -14,19 +14,4 @@ updates:
       - dependency-name: "*"
         update-types:
           - "version-update:semver-patch"
-          - "version-update:semver-major" 
-
-  # =========================
-  # Gradle dependencies
-  # =========================
- - package-ecosystem: "gradle"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 3
-
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
-          - "version-update:semver-major" 
+          - "version-update:semver-major"

--- a/spring-boot-2-rest-service-filtering/.github/dependabot.yml
+++ b/spring-boot-2-rest-service-filtering/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
+    commit-message:
+      prefix: "deps:"
 
     ignore:
       - dependency-name: "*"

--- a/spring-boot-2-rest-service-filtering/pom.xml
+++ b/spring-boot-2-rest-service-filtering/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>
+        <version>4.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -18,7 +18,7 @@
     <description>Spring Boot 2 and REST - Example Project</description>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
     </properties>
 
     <dependencies>
@@ -34,7 +34,7 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
 
         <dependency>

--- a/spring-boot-2-rest-service-filtering/readme.md
+++ b/spring-boot-2-rest-service-filtering/readme.md
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>
+        <version>4.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -37,7 +37,7 @@
     <description>Spring Boot 2 and REST - Example Project</description>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
     </properties>
 
     <dependencies>
@@ -51,7 +51,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
 
         <dependency>

--- a/spring-boot-2-rest-service-validation/.github/dependabot.yml
+++ b/spring-boot-2-rest-service-validation/.github/dependabot.yml
@@ -9,21 +9,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
-
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
-          - "version-update:semver-major" 
-
-  # =========================
-  # Gradle dependencies
-  # =========================
- - package-ecosystem: "gradle"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "deps:"
 
     ignore:
       - dependency-name: "*"

--- a/spring-boot-2-rest-service-validation/pom.xml
+++ b/spring-boot-2-rest-service-validation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>
+        <version>4.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -18,7 +18,7 @@
     <description>Spring Boot 2 and REST - Example Project</description>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
     </properties>
 
     <dependencies>
@@ -34,7 +34,7 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
 
         <dependency>

--- a/spring-boot-2-rest-service-validation/readme.md
+++ b/spring-boot-2-rest-service-validation/readme.md
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>
+        <version>4.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -37,7 +37,7 @@
     <description>Spring Boot 2 and REST - Example Project</description>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
     </properties>
 
     <dependencies>
@@ -51,7 +51,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/spring-boot-2-rest-service-versioning/.github/dependabot.yml
+++ b/spring-boot-2-rest-service-versioning/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
+    commit-message:
+      prefix: "deps:"
 
     ignore:
       - dependency-name: "*"
@@ -16,17 +18,3 @@ updates:
           - "version-update:semver-patch"
           - "version-update:semver-major" 
 
-  # =========================
-  # Gradle dependencies
-  # =========================
- - package-ecosystem: "gradle"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 3
-
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
-          - "version-update:semver-major" 

--- a/spring-boot-2-rest-service-versioning/pom.xml
+++ b/spring-boot-2-rest-service-versioning/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>
+        <version>4.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -18,7 +18,7 @@
     <description>Spring Boot 2 and REST - Example Project</description>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
     </properties>
 
     <dependencies>
@@ -35,7 +35,7 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
 
         <dependency>

--- a/spring-boot-2-rest-service-versioning/readme.md
+++ b/spring-boot-2-rest-service-versioning/readme.md
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>
+        <version>4.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -37,7 +37,7 @@
     <description>Spring Boot 2 and REST - Example Project</description>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
     </properties>
 
     <dependencies>
@@ -51,7 +51,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
 
         <dependency>

--- a/spring-boot-2-rest-service-with-hateoas/pom.xml
+++ b/spring-boot-2-rest-service-with-hateoas/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>
+        <version>4.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -18,7 +18,7 @@
     <description>Spring Boot 2 and REST - Example Project</description>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
     </properties>
 
     <dependencies>
@@ -34,7 +34,7 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
 
         <dependency>

--- a/spring-boot-2-rest-service-with-hateoas/readme.md
+++ b/spring-boot-2-rest-service-with-hateoas/readme.md
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>
+        <version>4.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -37,7 +37,7 @@
     <description>Spring Boot 2 and REST - Example Project</description>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
     </properties>
 
     <dependencies>
@@ -53,7 +53,7 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
 
         <dependency>

--- a/spring-boot-2-rest-service-with-swagger/pom.xml
+++ b/spring-boot-2-rest-service-with-swagger/pom.xml
@@ -21,7 +21,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
         <maven-jar-plugin.version>3.1.1</maven-jar-plugin.version>
         <openai.version>2.8.9</openai.version>
     </properties>
@@ -39,7 +39,7 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
 
         <dependency>

--- a/spring-boot-2-rest-service-with-swagger/readme.md
+++ b/spring-boot-2-rest-service-with-swagger/readme.md
@@ -55,7 +55,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/spring-boot-basic-microservice/readme.md
+++ b/spring-boot-basic-microservice/readme.md
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>
+        <version>4.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -37,7 +37,7 @@
     <description>Microservices with Spring Boot and Spring Cloud - Currency Conversion Service</description>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
         <spring-cloud.version>2025.0.0</spring-cloud.version>
     </properties>
 
@@ -48,7 +48,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
 
         <dependency>
@@ -294,7 +294,7 @@ public class SpringBootMicroserviceCurrencyConversionApplicationTests {
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>
+        <version>4.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -307,7 +307,7 @@ public class SpringBootMicroserviceCurrencyConversionApplicationTests {
     <description>Microservices with Spring Boot and Spring Cloud - Eureka Naming Server</description>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
         <spring-cloud.version>2025.0.0</spring-cloud.version> <!-- aka Jubilee -->
     </properties>
 
@@ -438,7 +438,7 @@ public class SpringBootMicroserviceEurekaNamingServerApplicationTests {
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>
+        <version>4.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -451,7 +451,7 @@ public class SpringBootMicroserviceEurekaNamingServerApplicationTests {
     <description>Microservices with Spring Boot and Spring Cloud - Forex Service</description>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
         <spring-cloud.version>2025.0.0</spring-cloud.version>
     </properties>
 
@@ -466,7 +466,7 @@ public class SpringBootMicroserviceEurekaNamingServerApplicationTests {
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
 
         <dependency>

--- a/spring-boot-basic-microservice/spring-boot-microservice-currency-conversion-service/pom.xml
+++ b/spring-boot-basic-microservice/spring-boot-microservice-currency-conversion-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>
+        <version>4.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -18,7 +18,7 @@
     <description>Microservices with Spring Boot and Spring Cloud - Currency Conversion Service</description>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
         <spring-cloud.version>2025.0.0</spring-cloud.version>
     </properties>
 
@@ -29,7 +29,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
 
         <dependency>

--- a/spring-boot-basic-microservice/spring-boot-microservice-eureka-naming-server/pom.xml
+++ b/spring-boot-basic-microservice/spring-boot-microservice-eureka-naming-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>
+        <version>4.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -18,7 +18,7 @@
     <description>Microservices with Spring Boot and Spring Cloud - Eureka Naming Server</description>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
         <spring-cloud.version>2025.0.0</spring-cloud.version>
     </properties>
 

--- a/spring-boot-basic-microservice/spring-boot-microservice-forex-service/pom.xml
+++ b/spring-boot-basic-microservice/spring-boot-microservice-forex-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>
+        <version>4.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -18,7 +18,7 @@
     <description>Microservices with Spring Boot and Spring Cloud - Forex Service</description>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
         <spring-cloud.version>2025.0.0</spring-cloud.version>
     </properties>
 
@@ -33,7 +33,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
 
         <dependency>

--- a/spring-boot-kotlin-basics-configuration/pom.xml
+++ b/spring-boot-kotlin-basics-configuration/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>
+        <version>4.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -18,7 +18,7 @@
     <description>Spring Boot Tutorial - Application Configuration with Profiles and YAML</description>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
         <kotlin.version>2.2.0</kotlin.version>
     </properties>
 
@@ -35,7 +35,7 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
 
         <dependency>

--- a/spring-boot-kotlin-basics-configuration/readme.md
+++ b/spring-boot-kotlin-basics-configuration/readme.md
@@ -27,7 +27,7 @@ Current Directory : /in28Minutes/git/spring-boot-examples/spring-boot-tutorial-b
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>
+        <version>4.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -40,7 +40,7 @@ Current Directory : /in28Minutes/git/spring-boot-examples/spring-boot-tutorial-b
     <description>Spring Boot Tutorial - Application Configuration with Profiles and YAML</description>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
         <kotlin.version>1.7.10</kotlin.version>
     </properties>
 
@@ -55,7 +55,7 @@ Current Directory : /in28Minutes/git/spring-boot-examples/spring-boot-tutorial-b
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
 
         <dependency>

--- a/spring-boot-react-examples/all-projects.md
+++ b/spring-boot-react-examples/all-projects.md
@@ -415,7 +415,7 @@ export default App;
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
+			<artifactId>spring-boot-starter-webmvc</artifactId>
 		</dependency>
 
 		<dependency>
@@ -1103,7 +1103,7 @@ export default App;
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
+			<artifactId>spring-boot-starter-webmvc</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>io.jsonwebtoken</groupId>
@@ -1986,7 +1986,7 @@ public class SpringBootFullStackJwtAuthLoginLogoutApplication {
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
+			<artifactId>spring-boot-starter-webmvc</artifactId>
 		</dependency>
 
 		<dependency>
@@ -3026,7 +3026,7 @@ export default App;
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
+			<artifactId>spring-boot-starter-webmvc</artifactId>
 		</dependency>
 
 		<dependency>
@@ -4268,7 +4268,7 @@ export default App;
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
+			<artifactId>spring-boot-starter-webmvc</artifactId>
 		</dependency>
 
 		<dependency>

--- a/spring-boot-react-examples/spring-boot-react-basic-auth-login-logout/backend-spring-boot-react-basic-auth-login-logout/pom.xml
+++ b/spring-boot-react-examples/spring-boot-react-basic-auth-login-logout/backend-spring-boot-react-basic-auth-login-logout/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>
+        <version>4.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -16,7 +16,7 @@
     <description>Demo project for Spring Boot</description>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
     </properties>
 
     <dependencies>
@@ -26,7 +26,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/spring-boot-react-examples/spring-boot-react-cors-cross-origin-csrf/backend-spring-boot-react-cors-cross-origin-csrf/pom.xml
+++ b/spring-boot-react-examples/spring-boot-react-cors-cross-origin-csrf/backend-spring-boot-react-cors-cross-origin-csrf/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>
+        <version>4.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.in28minutes.fullstack.springboot.react.rest.api</groupId>
@@ -15,13 +15,13 @@
     <description>Demo project for Spring Boot</description>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
 		<dependency>
             <groupId>org.springframework.boot</groupId>

--- a/spring-boot-react-examples/spring-boot-react-crud-full-stack-with-maven/backend-spring-boot-react-crud-full-stack-with-maven/pom.xml
+++ b/spring-boot-react-examples/spring-boot-react-crud-full-stack-with-maven/backend-spring-boot-react-crud-full-stack-with-maven/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>
+        <version>4.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.in28minutes.fullstack.springboot.maven.crud</groupId>
@@ -15,13 +15,13 @@
     <description>Demo project for Spring Boot</description>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/spring-boot-react-examples/spring-boot-react-hello-world-with-routing/backend-spring-boot-react-hello-world-with-routing/pom.xml
+++ b/spring-boot-react-examples/spring-boot-react-hello-world-with-routing/backend-spring-boot-react-hello-world-with-routing/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>
+        <version>4.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.in28minutes.fullstack.springboot.react.helloworld</groupId>
@@ -16,13 +16,13 @@
     <description>Demo project for Spring Boot</description>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
 
         <dependency>

--- a/spring-boot-react-examples/spring-boot-react-jpa-hibernate-with-h2-full-stack/backend-spring-boot-react-jpa-hibernate-with-h2-full-stack/pom.xml
+++ b/spring-boot-react-examples/spring-boot-react-jpa-hibernate-with-h2-full-stack/backend-spring-boot-react-jpa-hibernate-with-h2-full-stack/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>
+        <version>4.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.in28minutes.fullstack.springboot.react.jpa.hibernate</groupId>
@@ -15,7 +15,7 @@
     <description>Demo project for Spring Boot</description>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
     </properties>
 
     <dependencies>
@@ -25,7 +25,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
 
         <dependency>

--- a/spring-boot-react-examples/spring-boot-react-jwt-auth-login-logout/backend-spring-boot-react-jwt-auth-login-logout/pom.xml
+++ b/spring-boot-react-examples/spring-boot-react-jwt-auth-login-logout/backend-spring-boot-react-jwt-auth-login-logout/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>
+        <version>4.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.in28minutes.fullstack.springboot.jwt.basic.authentication</groupId>
@@ -15,7 +15,7 @@
     <description>Demo project for Spring Boot</description>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
     </properties>
 
     <dependencies>
@@ -25,7 +25,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/spring-boot-rest-services-with-unit-and-integration-tests/pom.xml
+++ b/spring-boot-rest-services-with-unit-and-integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>
+        <version>4.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -18,7 +18,7 @@
     <description>Demo project for Spring Boot</description>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
     </properties>
 
     <dependencies>
@@ -28,7 +28,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
 
         <dependency>

--- a/spring-boot-rest-services-with-unit-and-integration-tests/readme.md
+++ b/spring-boot-rest-services-with-unit-and-integration-tests/readme.md
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>
+        <version>4.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -47,7 +47,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
 
         <dependency>

--- a/spring-boot-rest-services/pom.xml
+++ b/spring-boot-rest-services/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>
+        <version>4.0.0</version>
     </parent>
 
     <groupId>com.in28minutes.springboot</groupId>
@@ -12,13 +12,13 @@
     <version>0.0.1-SNAPSHOT</version>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
 
         <dependency>

--- a/spring-boot-rest-services/readme.md
+++ b/spring-boot-rest-services/readme.md
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>
+        <version>4.0.0</version>
     </parent>
 
     <groupId>com.in28minutes.springboot</groupId>
@@ -32,13 +32,13 @@
     <version>0.0.1-SNAPSHOT</version>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
 
         <dependency>

--- a/spring-boot-tutorial-basics-configuration/pom.xml
+++ b/spring-boot-tutorial-basics-configuration/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>
+        <version>4.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -18,7 +18,7 @@
     <description>Spring Boot Tutorial - Application Configuration with Profiles and YAML</description>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
     </properties>
 
     <dependencies>
@@ -34,7 +34,7 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
 
         <dependency>

--- a/spring-boot-tutorial-basics-configuration/readme.md
+++ b/spring-boot-tutorial-basics-configuration/readme.md
@@ -28,7 +28,7 @@ Current Directory : /in28Minutes/git/spring-boot-examples/spring-boot-tutorial-b
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>
+        <version>4.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -41,7 +41,7 @@ Current Directory : /in28Minutes/git/spring-boot-examples/spring-boot-tutorial-b
     <description>Spring Boot Tutorial - Application Configuration with Profiles and YAML</description>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
     </properties>
 
     <dependencies>
@@ -57,7 +57,7 @@ Current Directory : /in28Minutes/git/spring-boot-examples/spring-boot-tutorial-b
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
 
         <dependency>

--- a/spring-boot-tutorial-basics/pom.xml
+++ b/spring-boot-tutorial-basics/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>
+        <version>4.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -18,7 +18,7 @@
     <description>Spring Boot Tutorial - Basic Concept Examples</description>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
     </properties>
 
     <dependencies>
@@ -29,7 +29,7 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
 
         <dependency>

--- a/spring-boot-tutorial-basics/readme.md
+++ b/spring-boot-tutorial-basics/readme.md
@@ -28,7 +28,7 @@ Current Directory : /in28Minutes/git/spring-boot-examples/spring-boot-tutorial-b
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>
+        <version>4.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -41,7 +41,7 @@ Current Directory : /in28Minutes/git/spring-boot-examples/spring-boot-tutorial-b
     <description>Spring Boot Tutorial - Basic Concept Examples</description>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
     </properties>
 
     <dependencies>
@@ -51,7 +51,7 @@ Current Directory : /in28Minutes/git/spring-boot-examples/spring-boot-tutorial-b
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/spring-boot-tutorial-soap-web-services/pom.xml
+++ b/spring-boot-tutorial-soap-web-services/pom.xml
@@ -14,13 +14,13 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.0-M1</version>		<relativePath /> <!-- lookup parent from repository -->
+		<version>4.0.0</version>		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<java.version>21</java.version>
+		<java.version>25</java.version>
 		<maven-jar-plugin.version>3.1.1</maven-jar-plugin.version>
 	</properties>
 

--- a/spring-boot-tutorial-soap-web-services/readme.md
+++ b/spring-boot-tutorial-soap-web-services/readme.md
@@ -43,13 +43,13 @@ Current Directory : /in28Minutes/git/spring-boot-examples/spring-boot-tutorial-s
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>		<relativePath /> <!-- lookup parent from repository -->
+        <version>4.0.0</version>		<relativePath /> <!-- lookup parent from repository -->
     </parent>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
         <maven-jar-plugin.version>3.1.1</maven-jar-plugin.version>
     </properties>
 

--- a/spring-boot-web-application-bootstrap-jquery/pom.xml
+++ b/spring-boot-web-application-bootstrap-jquery/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>
+        <version>4.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -18,13 +18,13 @@
     <description>Spring Boot Tutorial - Adding Bootstrap and JQuery to Web Application</description>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
 
         <dependency>

--- a/spring-boot-web-application-bootstrap-jquery/readme.md
+++ b/spring-boot-web-application-bootstrap-jquery/readme.md
@@ -32,7 +32,7 @@ Current Directory : /in28Minutes/git/spring-boot-examples/spring-boot-web-applic
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>
+        <version>4.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -45,13 +45,13 @@ Current Directory : /in28Minutes/git/spring-boot-examples/spring-boot-web-applic
     <description>Spring Boot Tutorial - Adding Bootstrap and JQuery to Web Application</description>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
 
         <dependency>

--- a/spring-boot-web-application/pom.xml
+++ b/spring-boot-web-application/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>
+        <version>4.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -18,7 +18,7 @@
     <description>Demo project for Spring Boot</description>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
     </properties>
 
     <dependencies>
@@ -29,7 +29,7 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
 
         <dependency>

--- a/spring-boot-web-application/readme.md
+++ b/spring-boot-web-application/readme.md
@@ -28,7 +28,7 @@ Current Directory : /in28Minutes/git/spring-boot-examples/spring-boot-web-applic
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.0-M1</version>
+        <version>4.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -51,7 +51,7 @@ Current Directory : /in28Minutes/git/spring-boot-examples/spring-boot-web-applic
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Bump spring-boot-starter-parent from 4.0.0-M1 to 4.0.0 and update <java.version> from 21 to 25 across many modules. Replace occurrences of spring-boot-starter-web with spring-boot-starter-webmvc in pom.xml files and README dependency examples. Also tidy up .github/dependabot.yml entries (remove duplicated Gradle section / fix update-types formatting). These changes apply to multiple sample projects and documentation.